### PR TITLE
Update Converter.ts

### DIFF
--- a/src/td/converter/Converter.ts
+++ b/src/td/converter/Converter.ts
@@ -341,7 +341,7 @@ module td
 
 
             function extractTypeParameterType(node:ts.TypeReferenceNode, type:ts.Type):Type {
-                if (node) {
+                if (node && node.typeName) {
                     var name = node.typeName['text'];
                     if (typeParameters[name]) {
                         return typeParameters[name];


### PR DESCRIPTION
Running TypeDoc for the following code snippet results in an error in the `extractTypeParameterType` function: 

```typescript
class Example<T> {
    set Something(SomeValue: T) {
    }
}
```

The object node.typeName is `null` for the set accessor. This problem only occurs when the argument of the setter is a generic type variable. Changing `SomeValue: T` to `SomeValue: string` does not result in an error.

This can be fixed by adding an extra condition to the function. After this fix documentation seems to be generated correctly and no further errors occur.