### PR TITLE
fix basic example run script missing ES5 target

### DIFF
--- a/examples/basic/run
+++ b/examples/basic/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd ${0%/*}
-node ../../bin/typedoc --module commonjs --includes inc/ --media media/ --out doc/ src/
+node ../../bin/typedoc --module commonjs --includes inc/ --media media/ --target ES5 --out doc/ src/


### PR DESCRIPTION
Compiler ES5 target was missing, therefore errors occurred when trying to run the script.