### PR TITLE
Create property declarations from constructor parameter properties

### DIFF
--- a/test/converter/class/class.ts
+++ b/test/converter/class/class.ts
@@ -63,4 +63,16 @@ export class TestSubClass extends TestClass
      * protectedMethod short text.
      */
     protected protectedMethod() {}
+
+    /**
+     * Constructor short text.
+     *
+     * @param p1 Constructor param
+     * @param p2 Private string property
+     * @param p3 Public number property
+     * @param p4 Public implicit any property
+     */
+    constructor(p1, private p2: string, public p3: number, public p4) {
+        super();
+    }
 }

--- a/test/converter/class/specs.json
+++ b/test/converter/class/specs.json
@@ -266,7 +266,7 @@
           },
           "children": [
             {
-              "id": 23,
+              "id": 21,
               "name": "constructor",
               "kind": 512,
               "kindString": "Constructor",
@@ -278,7 +278,7 @@
               },
               "signatures": [
                 {
-                  "id": 24,
+                  "id": 25,
                   "name": "new TestSubClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
@@ -286,26 +286,135 @@
                   "comment": {
                     "shortText": "Constructor short text."
                   },
+                  "parameters": [
+                    {
+                      "id": 26,
+                      "name": "p1",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Constructor param"
+                      },
+                      "type": {
+                        "type": "instrinct",
+                        "name": "any"
+                      }
+                    },
+                    {
+                      "id": 27,
+                      "name": "p2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Private string property"
+                      },
+                      "type": {
+                        "type": "instrinct",
+                        "name": "string"
+                      }
+                    },
+                    {
+                      "id": 28,
+                      "name": "p3",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Public number property"
+                      },
+                      "type": {
+                        "type": "instrinct",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 29,
+                      "name": "p4",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Public implicit any property\n"
+                      },
+                      "type": {
+                        "type": "instrinct",
+                        "name": "any"
+                      }
+                    }
+                  ],
                   "type": {
                     "type": "reference",
                     "name": "TestSubClass",
                     "id": 16
                   },
-                  "inheritedFrom": {
+                  "overwrites": {
                     "type": "reference",
                     "name": "TestClass.__constructor",
                     "id": 6
                   }
                 }
               ],
-              "inheritedFrom": {
+              "overwrites": {
                 "type": "reference",
                 "name": "TestClass.__constructor",
                 "id": 6
               }
             },
             {
-              "id": 21,
+              "id": 22,
+              "name": "p2",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPrivate": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "Private string property"
+              },
+              "type": {
+                "type": "instrinct",
+                "name": "string"
+              }
+            },
+            {
+              "id": 23,
+              "name": "p3",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPublic": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "Public number property"
+              },
+              "type": {
+                "type": "instrinct",
+                "name": "number"
+              }
+            },
+            {
+              "id": 24,
+              "name": "p4",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPublic": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "Public implicit any property"
+              },
+              "type": {
+                "type": "instrinct",
+                "name": "any"
+              }
+            },
+            {
+              "id": 30,
               "name": "publicProperty",
               "kind": 1024,
               "kindString": "Property",
@@ -327,7 +436,7 @@
               }
             },
             {
-              "id": 22,
+              "id": 31,
               "name": "staticProperty",
               "kind": 1024,
               "kindString": "Property",
@@ -422,7 +531,7 @@
               }
             },
             {
-              "id": 25,
+              "id": 32,
               "name": "staticMethod",
               "kind": 2048,
               "kindString": "Method",
@@ -432,7 +541,7 @@
               },
               "signatures": [
                 {
-                  "id": 26,
+                  "id": 33,
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
@@ -463,15 +572,18 @@
               "title": "Constructors",
               "kind": 512,
               "children": [
-                23
+                21
               ]
             },
             {
               "title": "Properties",
               "kind": 1024,
               "children": [
-                21,
-                22
+                22,
+                23,
+                24,
+                30,
+                31
               ]
             },
             {
@@ -480,7 +592,7 @@
               "children": [
                 19,
                 17,
-                25
+                32
               ]
             }
           ],

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -26,7 +26,7 @@ function compareDirectories(a, b) {
     var bFiles = getFileIndex(b);
     Assert.deepEqual(aFiles, bFiles, "Generated files differ.");
 
-    var gitHubRegExp = /https:\/\/github.com\/sebastian-lenz\/typedoc\/blob\/[^\/]*\/examples/g;
+    var gitHubRegExp = /https:\/\/github.com\/[A-Za-z0-9\-]+\/typedoc\/blob\/[^\/]*\/examples/g;
     aFiles.forEach(function (file) {
         var aSrc = FS.readFileSync(Path.join(a, file), {encoding:'utf-8'})
             .replace("\r", '')


### PR DESCRIPTION
TypeScript has a shortcut syntax to declare properties, by using access modifiers on constructor parameters.

I was missing this so support for it is added now.

Covers:
- parameter name
- type
- visibility
- @param comment => property description