### PR TITLE
Display readme in index.html even if entryPoint is specified, see #114

### DIFF
--- a/src/td/output/themes/DefaultTheme.ts
+++ b/src/td/output/themes/DefaultTheme.ts
@@ -157,7 +157,7 @@ module td.output
             } else {
                 entryPoint.url = 'globals.html';
                 urls.push(new UrlMapping('globals.html', entryPoint, 'reflection.hbs'));
-                urls.push(new UrlMapping('index.html',   entryPoint, 'index.hbs'));
+                urls.push(new UrlMapping('index.html',   project, 'index.hbs'));
             }
 
             if (entryPoint.children) {


### PR DESCRIPTION
This is my fairly naive fix to #114. Currently `index.html` is blank because `entryPoint.readme` is undefined. If `readme != "none"`, the object passed to `index.html` should be `project` instead.