### PR TITLE
Some improvements to development workflow:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /examples/doppio/src/
 /node_modules/
 /typescript/
+/coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
 node_js:
   - "0.10"
-
-before_install:
-  - npm install -g mocha

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -56,6 +56,14 @@ module.exports = function(grunt)
                 files: ['src/**/*.ts'],
                 tasks: ['ts:typedoc', 'string-replace:version']
             }
+        },
+        mocha_istanbul: {
+            coverage: {
+                src: 'test',
+                options: {
+                    mask: '*.js'
+                }
+            }
         }
     });
 
@@ -64,8 +72,10 @@ module.exports = function(grunt)
     grunt.loadNpmTasks('grunt-string-replace');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-ts');
+    grunt.loadNpmTasks('grunt-mocha-istanbul');
 
     grunt.registerTask('default', ['ts:typedoc', 'string-replace:version']);
+    grunt.registerTask('build_and_test', ['default', 'specs', 'mocha_istanbul:coverage']);
     grunt.registerTask('specs', ['clean:specsBefore', 'build-specs', 'clean:specsAfter']);
 
     grunt.registerTask('build-specs', function() {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-string-replace": "^1.2.0",
-    "grunt-ts": "^4.2.0-beta"
+    "grunt-ts": "^4.2.0-beta",
+    "grunt-mocha-istanbul": "^2.4.0",
+    "istanbul": "^0.3.17",
+    "mocha": "^2.2.5"
   },
   "files": [
     "bin",


### PR DESCRIPTION
* Explicitly declare dependency to mocha.
  This helps avoid depending on a globaly installed mocha package
  As npm scripts (npm test) add node_modules/.bin/ to their PATH.

* A single Grunt task to compile/create test artifacts/run tests/create
  coverage report (created in ./coverage dir).