### PR TITLE
Fixes TypeError when attempting to call copyFrom on an undefined comment.

### DIFF
--- a/bin/typedoc.js
+++ b/bin/typedoc.js
@@ -5240,7 +5240,9 @@ var td;
                     if (target instanceof td.models.SignatureReflection && target.parameters &&
                         source instanceof td.models.SignatureReflection && source.parameters) {
                         for (var index = 0, count = target.parameters.length; index < count; index++) {
-                            target.parameters[index].comment.copyFrom(source.parameters[index].comment);
+                            if (target.parameters[index].comment) {
+                                target.parameters[index].comment.copyFrom(source.parameters[index].comment);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Null check to ensure comment exists before calling its copyFrom method. It's not entirely clear to me why the comment is undefined in my specific case.