### PR TITLE
Default export fix

### DIFF
--- a/bin/typedoc.js
+++ b/bin/typedoc.js
@@ -3789,7 +3789,13 @@ var td;
             if (!name) {
                 if (!node.symbol)
                     return null;
-                name = node.symbol.name;
+                // Get name (even of default export)
+                if (node.localSymbol) {
+                    name = node.localSymbol.name;
+                }
+                else {
+                    name = node.symbol.name;
+                }
             }
             // Test whether the node is exported
             var isExported;

--- a/examples/basic/src/default-export.ts
+++ b/examples/basic/src/default-export.ts
@@ -9,19 +9,19 @@
 class NotExportedClassName
 {
     /**
-     * Property of not exported class.
+     * Property of NotExportedClassName class.
      */
     public notExportedProperty:string;
 
 
     /**
-     * This is the constructor of the not exported class.
+     * This is the constructor of the NotExportedClassName class.
      */
     constructor() { }
 
 
     /**
-     * Method of not exported class.
+     * Method of NotExportedClassName class.
      */
     public getNotExportedProperty():string {
         return this.notExportedProperty;
@@ -33,29 +33,30 @@ class NotExportedClassName
  * This class is exported via es6 export syntax.
  *
  * ```
- * export default class SingleExportedClass
+ * export default class DefaultExportedClass
  * ```
  */
-export default class SingleExportedClass
+export default class DefaultExportedClass
 {
     /**
-     * Property of exported class.
+     * Property of default exported class.
      */
     public exportedProperty:string;
 
 
     /**
-     * This is the constructor of the exported class.
+     * This is the constructor of the default exported class.
      */
     constructor() { }
 
 
     /**
-     * Method of exported class.
+     * Method of default exported class.
      */
     public getExportedProperty():string {
         return this.exportedProperty;
     }
 }
 
+// Rename class on export
 export {NotExportedClassName as ExportedClassName};

--- a/examples/basic/src/default-export.ts
+++ b/examples/basic/src/default-export.ts
@@ -1,0 +1,61 @@
+/**
+ * This class is exported under a different name. The exported name is
+ * "ExportedClassName"
+ * 
+ * ```JavaScript
+ * export {NotExportedClassName as ExportedClassName};
+ * ```
+ */
+class NotExportedClassName
+{
+    /**
+     * Property of not exported class.
+     */
+    public notExportedProperty:string;
+
+
+    /**
+     * This is the constructor of the not exported class.
+     */
+    constructor() { }
+
+
+    /**
+     * Method of not exported class.
+     */
+    public getNotExportedProperty():string {
+        return this.notExportedProperty;
+    }
+}
+
+
+/**
+ * This class is exported via es6 export syntax.
+ *
+ * ```
+ * export default class SingleExportedClass
+ * ```
+ */
+export default class SingleExportedClass
+{
+    /**
+     * Property of exported class.
+     */
+    public exportedProperty:string;
+
+
+    /**
+     * This is the constructor of the exported class.
+     */
+    constructor() { }
+
+
+    /**
+     * Method of exported class.
+     */
+    public getExportedProperty():string {
+        return this.exportedProperty;
+    }
+}
+
+export {NotExportedClassName as ExportedClassName};


### PR DESCRIPTION
Fix for sebastian-lenz/typedoc#111

![image](https://cloud.githubusercontent.com/assets/11273838/9976781/8ffaa88e-5ebc-11e5-9ce7-162f519f60b5.png)


Renamed exports are still documented as their local name which might be unexpected.
![image](https://cloud.githubusercontent.com/assets/11273838/9976790/029458e0-5ebd-11e5-9a4f-f1b28371b85b.png)

I wasn't sure how to add tests for this change.